### PR TITLE
Add service worker for offline support

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ When encrypting text or files, you can generate a shareable link. Anyone with th
 ## ⚠️ Security & Connectivity Notes
 
 - All encryption is performed **client-side** — your passphrase is never stored or transmitted.
-- **Offline Functionality:** Although the encryption operations run entirely offline once the app is loaded, an internet connection is required for the initial loading of external JavaScript libraries. A future release will host these libraries locally, eliminating this dependency.
+- **Offline Functionality:** The app caches its assets using a service worker, so after the first load HexaShift can run completely offline, including the external libraries.
 - Choose a strong, unique passphrase to maximize security.
 - The app **does not support forward secrecy** or digital signatures.
 - Designed for **anonymity and plausible deniability**, not for audit logs or compliance.

--- a/index.html
+++ b/index.html
@@ -502,5 +502,12 @@
       });
     });
   </script>
+  <script>
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', () => {
+        navigator.serviceWorker.register('sw.js');
+      });
+    }
+  </script>
 </body>
 </html>

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,33 @@
+const CACHE_NAME = 'hexashift-cache-v1';
+const APP_ASSETS = [
+  './',
+  './index.html',
+  './alice.html',
+  './sw.js',
+  'https://cdn.jsdelivr.net/npm/zxcvbn@4.4.2/dist/zxcvbn.js',
+  'https://cdn.jsdelivr.net/npm/qrcode@1.4.4/build/qrcode.min.js',
+  'https://cdn.jsdelivr.net/npm/jsqr@1.4.0/dist/jsQR.js',
+  'https://img.freepik.com/free-vector/padlock-coloured-outline_78370-548.jpg'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(APP_ASSETS))
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys => Promise.all(
+      keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key))
+    ))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => {
+      return response || fetch(event.request);
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- create `sw.js` to cache site assets and serve requests offline
- register the service worker in `index.html`
- document new offline capability in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f04f15314833185860974cb7be135