### PR TITLE
Add Argon2 optional KDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ No logs. No identities. No dependencies.
 
 - **AES-256-GCM** encryption via the WebCrypto API
 - **PBKDF2** key derivation (150k iterations, SHA-256)
+- Optional **Argon2id** key derivation (64MB memory, 3 iterations)
 - Custom passphrase input with a strength meter powered by **zxcvbn**
 - Encrypt and decrypt text, images, and encrypted text files
 - **Image Encryption** with MIME type preservation and auto-download of decrypted files  
@@ -28,6 +29,12 @@ No logs. No identities. No dependencies.
 - Copy-to-clipboard functionality
 - Mobile-first responsive layout
 - Fully offline, installable PWA experience on Android and desktop
+
+## 🔑 Key Derivation Options
+
+Use the dropdown beneath the passphrase field to select **PBKDF2** or **Argon2id**.
+Argon2id employs 64MB of memory and 3 iterations for strong resistance
+to brute-force attacks.
 
 ## 🔐 Passphrase Guidelines
 
@@ -70,6 +77,7 @@ When encrypting text or files, you can generate a shareable link. Anyone with th
 - All encryption is performed **client-side** — your passphrase is never stored or transmitted.
 - **Offline Functionality:** Although the encryption operations run entirely offline once the app is loaded, an internet connection is required for the initial loading of external JavaScript libraries. A future release will host these libraries locally, eliminating this dependency.
 - Choose a strong, unique passphrase to maximize security.
+- Using **Argon2id** greatly increases CPU and memory usage (64MB by default). Expect slower operations on low-powered devices.
 - The app **does not support forward secrecy** or digital signatures.
 - Designed for **anonymity and plausible deniability**, not for audit logs or compliance.
 

--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@
   <script src="https://cdn.jsdelivr.net/npm/zxcvbn@4.4.2/dist/zxcvbn.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/qrcode@1.4.4/build/qrcode.min.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/jsqr@1.4.0/dist/jsQR.js" defer></script>
+  <script src="https://cdn.jsdelivr.net/npm/argon2-browser/dist/argon2-bundled.min.js" defer></script>
   <style>
     body {
       font-family: Arial, sans-serif;
@@ -136,6 +137,11 @@
     <label for="key">Passphrase:</label>
     <input type="password" id="key" oninput="checkStrength()" placeholder="Enter your passphrase">
     <button onclick="togglePasswordVisibility()">Toggle Visibility</button>
+    <label for="kdf" style="margin-top:1rem;">Key Derivation:</label>
+    <select id="kdf">
+      <option value="pbkdf2" selected>PBKDF2</option>
+      <option value="argon2id">Argon2id</option>
+    </select>
     <div id="strength"></div>
     
     <div class="tools" style="margin-top: 10px;">
@@ -200,17 +206,43 @@
       navigator.clipboard.writeText(cleaned).then(() => alert('Copied!')); 
     }
     
-    function resetForm() { 
-      document.getElementById('action').value = 'encryptText'; 
-      adjustView(); 
-      document.getElementById('message').value = ''; 
+    function resetForm() {
+      document.getElementById('action').value = 'encryptText';
+      adjustView();
+      document.getElementById('message').value = '';
       document.getElementById('fileInput').value = '';
       document.getElementById('imageInput').value = '';
       document.getElementById('qrInput').value = '';
       document.getElementById('key').value = ''; 
       document.getElementById('result').textContent = ''; 
       document.getElementById('strength').textContent = ''; 
-      document.getElementById('qrcode').innerHTML = ''; 
+      document.getElementById('qrcode').innerHTML = '';
+    }
+
+    async function deriveAesKey(passphrase, salt, usages) {
+      const kdf = document.getElementById('kdf').value;
+      if (kdf === 'argon2id') {
+        const { hashHex } = await argon2.hash({
+          pass: passphrase,
+          salt,
+          time: 3,
+          mem: 64 * 1024,
+          parallelism: 1,
+          hashLen: 32,
+          type: argon2.ArgonType.Argon2id
+        });
+        const keyBytes = Uint8Array.from(hashHex.match(/.{2}/g).map(b => parseInt(b, 16)));
+        return crypto.subtle.importKey('raw', keyBytes, { name: 'AES-GCM' }, false, usages);
+      }
+      const enc = new TextEncoder();
+      const keyMaterial = await crypto.subtle.importKey('raw', enc.encode(passphrase), 'PBKDF2', false, ['deriveKey']);
+      return crypto.subtle.deriveKey(
+        { name: 'PBKDF2', salt, iterations: 150000, hash: 'SHA-256' },
+        keyMaterial,
+        { name: 'AES-GCM', length: 256 },
+        false,
+        usages
+      );
     }
     
     document.addEventListener('DOMContentLoaded', () => { 
@@ -241,14 +273,7 @@
             const message = document.getElementById('message').value; 
             const salt = crypto.getRandomValues(new Uint8Array(16));
             const iv = crypto.getRandomValues(new Uint8Array(12));
-            const keyMaterial = await crypto.subtle.importKey("raw", enc.encode(passphrase), "PBKDF2", false, ["deriveKey"]);
-            const key = await crypto.subtle.deriveKey(
-              { name: "PBKDF2", salt, iterations: 150000, hash: "SHA-256" },
-              keyMaterial,
-              { name: "AES-GCM", length: 256 },
-              false,
-              ["encrypt", "decrypt"]
-            );
+            const key = await deriveAesKey(passphrase, salt, ["encrypt", "decrypt"]);
             const ciphertext = await crypto.subtle.encrypt({ name: "AES-GCM", iv }, key, enc.encode(message));
             const combined = new Uint8Array([...salt, ...iv, ...new Uint8Array(ciphertext)]);
             const output = btoa(String.fromCharCode(...combined));
@@ -278,14 +303,7 @@
             const salt = data.slice(0, 16);
             const iv = data.slice(16, 28);
             const ciphertext = data.slice(28);
-            const keyMaterial = await crypto.subtle.importKey("raw", enc.encode(passphrase), "PBKDF2", false, ["deriveKey"]);
-            const key = await crypto.subtle.deriveKey(
-              { name: "PBKDF2", salt, iterations: 150000, hash: "SHA-256" },
-              keyMaterial,
-              { name: "AES-GCM", length: 256 },
-              false,
-              ["decrypt"]
-            );
+            const key = await deriveAesKey(passphrase, salt, ["decrypt"]);
             const decrypted = await crypto.subtle.decrypt({ name: "AES-GCM", iv }, key, ciphertext);
             const sepIndex = new Uint8Array(decrypted).indexOf(124);
             if (sepIndex !== -1) {
@@ -311,14 +329,7 @@
                 const salt = data.slice(0, 16);
                 const iv = data.slice(16, 28);
                 const ciphertext = data.slice(28);
-                const keyMaterial = await crypto.subtle.importKey("raw", enc.encode(passphrase), "PBKDF2", false, ["deriveKey"]);
-                const key = await crypto.subtle.deriveKey(
-                  { name: "PBKDF2", salt, iterations: 150000, hash: "SHA-256" },
-                  keyMaterial,
-                  { name: "AES-GCM", length: 256 },
-                  false,
-                  ["decrypt"]
-                );
+                const key = await deriveAesKey(passphrase, salt, ["decrypt"]);
                 const decrypted = await crypto.subtle.decrypt({ name: "AES-GCM", iv }, key, ciphertext);
                 const sepIndex = new Uint8Array(decrypted).indexOf(124);
                 if (sepIndex !== -1) {
@@ -371,14 +382,7 @@
       
       const salt = crypto.getRandomValues(new Uint8Array(16));
       const iv = crypto.getRandomValues(new Uint8Array(12));
-      const keyMaterial = await crypto.subtle.importKey("raw", new TextEncoder().encode(passphrase), "PBKDF2", false, ["deriveKey"]);
-      const key = await crypto.subtle.deriveKey(
-        { name: "PBKDF2", salt, iterations: 150000, hash: "SHA-256" },
-        keyMaterial,
-        { name: "AES-GCM", length: 256 },
-        false,
-        ["encrypt"]
-      );
+      const key = await deriveAesKey(passphrase, salt, ["encrypt"]);
       const ciphertext = await crypto.subtle.encrypt({ name: "AES-GCM", iv }, key, fullBuffer);
       const combined = new Uint8Array([...salt, ...iv, ...new Uint8Array(ciphertext)]);
       const output = btoa(String.fromCharCode(...combined));
@@ -433,14 +437,7 @@
               const salt = data.slice(0, 16);
               const iv = data.slice(16, 28);
               const ciphertext = data.slice(28);
-              const keyMaterial = await crypto.subtle.importKey("raw", enc.encode(passphrase), "PBKDF2", false, ["deriveKey"]);
-              const key = await crypto.subtle.deriveKey(
-                { name: "PBKDF2", salt, iterations: 150000, hash: "SHA-256" },
-                keyMaterial,
-                { name: "AES-GCM", length: 256 },
-                false,
-                ["decrypt"]
-              );
+              const key = await deriveAesKey(passphrase, salt, ["decrypt"]);
               const decrypted = await crypto.subtle.decrypt({ name: "AES-GCM", iv }, key, ciphertext);
               const sepIndex = new Uint8Array(decrypted).indexOf(124);
               if (sepIndex !== -1) {


### PR DESCRIPTION
## Summary
- add argon2-browser CDN reference and dropdown for KDF selection
- implement `deriveAesKey` helper to use PBKDF2 or Argon2
- document Argon2 option and performance considerations

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f04fb492c8331ba5ea7f152c97057