### PR TITLE
Add basic Node.js tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,15 @@ When encrypting text or files, you can generate a shareable link. Anyone with th
 - Scenarios requiring total local control
 - Privacy-conscious users avoiding centralized platforms
 
+## ✅ Running Tests
+
+This project uses the built-in Node.js test runner. After cloning the repo, run:
+
+```bash
+npm install
+npm test
+```
+
 ---
 
 Made with ❤️ in 🌵 for the privacy-minded.  

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "sset",
+  "version": "1.0.0",
+  "description": "**HexaShift** is a lightweight, offline encryption tool built for **privacy, simplicity, and control**. Designed as a standalone Progressive Web App (PWA), it enables peer-to-peer message and file encryption using high-entropy passphrases — with **no servers**, **no accounts**, and **no data collection**. Once loaded, HexaShift works entirely offline.",
+  "main": "index.js",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module"
+}

--- a/src/crypto.js
+++ b/src/crypto.js
@@ -1,0 +1,64 @@
+import { webcrypto } from 'crypto';
+
+const { subtle } = webcrypto;
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+
+export async function encryptText(message, passphrase) {
+  const salt = webcrypto.getRandomValues(new Uint8Array(16));
+  const iv = webcrypto.getRandomValues(new Uint8Array(12));
+  const keyMaterial = await subtle.importKey('raw', enc.encode(passphrase), 'PBKDF2', false, ['deriveKey']);
+  const key = await subtle.deriveKey({ name: 'PBKDF2', salt, iterations: 150000, hash: 'SHA-256' }, keyMaterial, { name: 'AES-GCM', length: 256 }, false, ['encrypt']);
+  const ciphertext = await subtle.encrypt({ name: 'AES-GCM', iv }, key, enc.encode(message));
+  const combined = new Uint8Array([...salt, ...iv, ...new Uint8Array(ciphertext)]);
+  return Buffer.from(combined).toString('base64');
+}
+
+export async function decryptText(base64, passphrase) {
+  const data = Buffer.from(base64, 'base64');
+  const salt = data.subarray(0, 16);
+  const iv = data.subarray(16, 28);
+  const ciphertext = data.subarray(28);
+  const keyMaterial = await subtle.importKey('raw', enc.encode(passphrase), 'PBKDF2', false, ['deriveKey']);
+  const key = await subtle.deriveKey({ name: 'PBKDF2', salt, iterations: 150000, hash: 'SHA-256' }, keyMaterial, { name: 'AES-GCM', length: 256 }, false, ['decrypt']);
+  const decrypted = await subtle.decrypt({ name: 'AES-GCM', iv }, key, ciphertext);
+  return dec.decode(decrypted);
+}
+
+export async function encryptImage(buffer, mimeType, passphrase) {
+  const prefix = enc.encode(`${mimeType}|`);
+  const full = new Uint8Array(prefix.length + buffer.length);
+  full.set(prefix);
+  full.set(buffer, prefix.length);
+  const salt = webcrypto.getRandomValues(new Uint8Array(16));
+  const iv = webcrypto.getRandomValues(new Uint8Array(12));
+  const keyMaterial = await subtle.importKey('raw', enc.encode(passphrase), 'PBKDF2', false, ['deriveKey']);
+  const key = await subtle.deriveKey({ name: 'PBKDF2', salt, iterations: 150000, hash: 'SHA-256' }, keyMaterial, { name: 'AES-GCM', length: 256 }, false, ['encrypt']);
+  const ciphertext = await subtle.encrypt({ name: 'AES-GCM', iv }, key, full);
+  const combined = new Uint8Array([...salt, ...iv, ...new Uint8Array(ciphertext)]);
+  return Buffer.from(combined).toString('base64');
+}
+
+export async function decryptImage(base64, passphrase) {
+  const data = Buffer.from(base64, 'base64');
+  const salt = data.subarray(0, 16);
+  const iv = data.subarray(16, 28);
+  const ciphertext = data.subarray(28);
+  const keyMaterial = await subtle.importKey('raw', enc.encode(passphrase), 'PBKDF2', false, ['deriveKey']);
+  const key = await subtle.deriveKey({ name: 'PBKDF2', salt, iterations: 150000, hash: 'SHA-256' }, keyMaterial, { name: 'AES-GCM', length: 256 }, false, ['decrypt']);
+  const decrypted = await subtle.decrypt({ name: 'AES-GCM', iv }, key, ciphertext);
+  const sep = new Uint8Array(decrypted).indexOf(124);
+  const mime = dec.decode(new Uint8Array(decrypted).subarray(0, sep));
+  const buf = Buffer.from(new Uint8Array(decrypted).subarray(sep + 1));
+  return { mimeType: mime, buffer: buf };
+}
+
+export function qrEncode(data) {
+  return `QR:${Buffer.from(data).toString('base64')}`;
+}
+
+export function qrDecode(qr) {
+  if (!qr.startsWith('QR:')) throw new Error('Invalid QR format');
+  const base = qr.slice(3);
+  return Buffer.from(base, 'base64').toString();
+}

--- a/test/crypto.test.js
+++ b/test/crypto.test.js
@@ -1,0 +1,27 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { encryptText, decryptText, encryptImage, decryptImage, qrEncode, qrDecode } from '../src/crypto.js';
+
+const PASS = 's3cr3t';
+
+// Helper buffer for image tests
+const IMG_BUF = Buffer.from('sampledata');
+
+test('encrypt and decrypt text', async () => {
+  const cipher = await encryptText('hello world', PASS);
+  const plain = await decryptText(cipher, PASS);
+  assert.equal(plain, 'hello world');
+});
+
+test('encrypt and decrypt image', async () => {
+  const cipher = await encryptImage(IMG_BUF, 'image/png', PASS);
+  const result = await decryptImage(cipher, PASS);
+  assert.equal(result.mimeType, 'image/png');
+  assert.deepEqual(result.buffer, IMG_BUF);
+});
+
+test('QR encode and decode', () => {
+  const qr = qrEncode('some text');
+  const text = qrDecode(qr);
+  assert.equal(text, 'some text');
+});


### PR DESCRIPTION
## Summary
- add Node-based crypto helpers and tests
- use Node test runner in package.json
- document how to run the tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f05074a0c8331b5173506396c2617