### PR TITLE
Add service worker for offline support

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ When encrypting text or files, you can generate a shareable link. Anyone with th
 ## ⚠️ Security & Connectivity Notes
 
 - All encryption is performed **client-side** — your passphrase is never stored or transmitted.
-- **Offline Functionality:** All dependencies (zxcvbn, qrcode, jsQR) are bundled in the `libs/` folder, so the app runs fully offline.
+- **Offline Functionality:** All dependencies (zxcvbn, qrcode, jsQR) are bundled in the `libs/` folder. A service worker caches app files after the first visit, so HexaShift works offline.
 - Choose a strong, unique passphrase to maximize security.
 - The app **does not support forward secrecy** or digital signatures.
 - Designed for **anonymity and plausible deniability**, not for audit logs or compliance.

--- a/index.html
+++ b/index.html
@@ -32,7 +32,14 @@
   <!-- Updated external library references -->
   <script src="libs/zxcvbn.js" defer></script>
   <script src="libs/qrcode.min.js" defer></script>
-  <script src="libs/jsQR.js" defer></script>
+    <script src="libs/jsQR.js" defer></script>
+    <script>
+      if ('serviceWorker' in navigator) {
+        window.addEventListener('load', () => {
+          navigator.serviceWorker.register('sw.js').catch(console.error);
+        });
+      }
+    </script>
   <style>
     body {
       font-family: Arial, sans-serif;

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,21 @@
+const CACHE_NAME = 'hexashift-cache-v1';
+const ASSETS = [
+  './',
+  './index.html',
+  './alice.html',
+  './libs/zxcvbn.js',
+  './libs/qrcode.min.js',
+  './libs/jsQR.js'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => response || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- register service worker in the main page
- implement `sw.js` for asset caching
- document new offline behaviour in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f03c45c0c8331abb2c2a40ab04808