### PR TITLE
Enforce passphrase strength using zxcvbn

### DIFF
--- a/alice.html
+++ b/alice.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Alice's Decryption Wonderland</title>
+  <script src="https://cdn.jsdelivr.net/npm/zxcvbn@4.4.2/dist/zxcvbn.js" defer></script>
   <style>
     /* Alice in Wonderland themed styling */
     body {
@@ -78,8 +79,9 @@
     <label for="encryptedCode">Encrypted Code:</label>
     <textarea id="encryptedCode" rows="6" placeholder="Paste your enchanted encrypted code here..."></textarea>
     <label for="passphrase">Passphrase:</label>
-    <input type="password" id="passphrase" placeholder="Enter your secret passphrase">
-    <button id="runButton">Run</button>
+    <input type="password" id="passphrase" oninput="checkStrength()" placeholder="Enter your secret passphrase">
+    <div id="strength"></div>
+    <button id="runButton" disabled>Run</button>
     <div id="output" class="output"></div>
   </div>
 
@@ -133,6 +135,18 @@
       }
     }
 
+    function checkStrength() {
+      const input = document.getElementById('passphrase').value;
+      const result = zxcvbn(input);
+      const levels = ['Very Weak', 'Weak', 'Fair', 'Good', 'Strong'];
+      document.getElementById('strength').textContent = 'Strength: ' + levels[result.score];
+      document.getElementById('runButton').disabled = result.score < 3;
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+      checkStrength();
+    });
+
     // Event listener for the Run button
     document.getElementById('runButton').addEventListener('click', async () => {
       const encryptedCode = document.getElementById('encryptedCode').value.trim();
@@ -145,6 +159,12 @@
 
       if (!encryptedCode || !passphrase) {
         outputDiv.textContent = "Please provide both the encrypted code and the passphrase.";
+        outputDiv.classList.add("error");
+        return;
+      }
+
+      if (zxcvbn(passphrase).score < 3) {
+        outputDiv.textContent = "Passphrase is too weak.";
         outputDiv.classList.add("error");
         return;
       }

--- a/index.html
+++ b/index.html
@@ -137,11 +137,11 @@
     <input type="password" id="key" oninput="checkStrength()" placeholder="Enter your passphrase">
     <button onclick="togglePasswordVisibility()">Toggle Visibility</button>
     <div id="strength"></div>
-    
+
     <div class="tools" style="margin-top: 10px;">
-      <button id="runButton">Run</button>
-      <button id="encryptImage">Encrypt Image</button>
-      <button id="decodeQR">Decode QR</button>
+      <button id="runButton" disabled>Run</button>
+      <button id="encryptImage" disabled>Encrypt Image</button>
+      <button id="decodeQR" disabled>Decode QR</button>
       <button onclick="resetForm()">Reset</button>
       <button onclick="copyToClipboard()">Copy Result</button>
     </div>
@@ -187,11 +187,15 @@
       keyInput.type = keyInput.type === 'password' ? 'text' : 'password'; 
     }
     
-    function checkStrength() { 
-      const input = document.getElementById('key').value; 
-      const result = zxcvbn(input); 
-      const levels = ['Very Weak', 'Weak', 'Fair', 'Good', 'Strong']; 
-      document.getElementById('strength').textContent = 'Strength: ' + levels[result.score]; 
+    function checkStrength() {
+      const input = document.getElementById('key').value;
+      const result = zxcvbn(input);
+      const levels = ['Very Weak', 'Weak', 'Fair', 'Good', 'Strong'];
+      document.getElementById('strength').textContent = 'Strength: ' + levels[result.score];
+      const strong = result.score >= 3;
+      document.getElementById('runButton').disabled = !strong;
+      document.getElementById('encryptImage').disabled = !strong;
+      document.getElementById('decodeQR').disabled = !strong;
     }
     
     function copyToClipboard() { 
@@ -207,10 +211,11 @@
       document.getElementById('fileInput').value = '';
       document.getElementById('imageInput').value = '';
       document.getElementById('qrInput').value = '';
-      document.getElementById('key').value = ''; 
-      document.getElementById('result').textContent = ''; 
-      document.getElementById('strength').textContent = ''; 
-      document.getElementById('qrcode').innerHTML = ''; 
+      document.getElementById('key').value = '';
+      document.getElementById('result').textContent = '';
+      document.getElementById('strength').textContent = '';
+      document.getElementById('qrcode').innerHTML = '';
+      checkStrength();
     }
     
     document.addEventListener('DOMContentLoaded', () => { 
@@ -218,6 +223,7 @@
       const enc = new TextEncoder();
       
       adjustView();
+      checkStrength();
       
       // Check for 'code' query parameter and set decryption view if present
       const params = new URLSearchParams(window.location.search);
@@ -229,12 +235,13 @@
       }
     
       document.getElementById('runButton').addEventListener('click', async () => { 
-        const action = document.getElementById('action').value; 
-        const passphrase = document.getElementById('key').value.trim(); 
-        const resultDiv = document.getElementById('result'); 
-        const qrCodeDiv = document.getElementById('qrcode'); 
-        qrCodeDiv.innerHTML = ''; 
+        const action = document.getElementById('action').value;
+        const passphrase = document.getElementById('key').value.trim();
+        const resultDiv = document.getElementById('result');
+        const qrCodeDiv = document.getElementById('qrcode');
+        qrCodeDiv.innerHTML = '';
         if (passphrase.length < 6) return alert('Passphrase must be at least 6 characters.');
+        if (zxcvbn(passphrase).score < 3) return alert('Passphrase is too weak.');
     
         try {
           if (action === 'encryptText') {
@@ -345,12 +352,12 @@
       });
     
       // Encrypt Image button handler
-  document.getElementById('encryptImage').addEventListener('click', async () => { 
-    const fileInput = document.getElementById('imageInput'); 
-    const resultDiv = document.getElementById('result'); 
-    const qrCodeDiv = document.getElementById('qrcode'); 
-    const passphrase = document.getElementById('key').value.trim(); 
-    if (!fileInput.files[0]) return alert('Please upload an image.'); 
+  document.getElementById('encryptImage').addEventListener('click', async () => {
+    const fileInput = document.getElementById('imageInput');
+    const resultDiv = document.getElementById('result');
+    const qrCodeDiv = document.getElementById('qrcode');
+    const passphrase = document.getElementById('key').value.trim();
+    if (!fileInput.files[0]) return alert('Please upload an image.');
 
     // Check if the image file size exceeds 100kb (100 * 1024 bytes)
     if (fileInput.files[0].size > 100 * 1024) {
@@ -359,6 +366,7 @@
     }
 
     if (passphrase.length < 6) return alert('Passphrase must be at least 6 characters.');
+    if (zxcvbn(passphrase).score < 3) return alert('Passphrase is too weak.');
     
     const reader = new FileReader();
     reader.onload = async function () {
@@ -409,11 +417,12 @@
     
       // Decode QR button handler
       document.getElementById('decodeQR').addEventListener('click', async () => { 
-        const fileInput = document.getElementById('qrInput'); 
-        const passphrase = document.getElementById('key').value.trim(); 
-        const resultDiv = document.getElementById('result'); 
-        if (!fileInput.files[0]) return alert('Please upload a QR code image.'); 
+        const fileInput = document.getElementById('qrInput');
+        const passphrase = document.getElementById('key').value.trim();
+        const resultDiv = document.getElementById('result');
+        if (!fileInput.files[0]) return alert('Please upload a QR code image.');
         if (passphrase.length < 6) return alert('Passphrase must be at least 6 characters.');
+        if (zxcvbn(passphrase).score < 3) return alert('Passphrase is too weak.');
     
         const reader = new FileReader();
         reader.onload = async function () {


### PR DESCRIPTION
## Summary
- Require passphrase score ≥3 before enabling encryption/decryption controls
- Apply zxcvbn-based validation to both main tool and Alice's page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68997bc6eef08331b9716acb137f7d89