### PR TITLE
Use URL hash to load and share encrypted data

### DIFF
--- a/index.html
+++ b/index.html
@@ -225,9 +225,8 @@
       adjustView();
       checkStrength();
       
-      // Check for 'code' query parameter and set decryption view if present
-      const params = new URLSearchParams(window.location.search);
-      const code = params.get('code');
+      // Check for code in URL hash and set decryption view if present
+      const code = window.location.hash.substring(1);
       if (code) {
         document.getElementById('action').value = 'decrypt';
         document.getElementById('message').value = code;
@@ -492,7 +491,7 @@
         }
     
         const url = new URL(window.location.href);
-        url.searchParams.set('code', cleaned);
+        url.hash = cleaned;
     
         const shareData = {
           title: 'Encrypted Message',


### PR DESCRIPTION
## Summary
- Read decryption data from `window.location.hash` on page load
- Share encrypted output by placing the code in the URL hash

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68997cd8b394833186f90fecbc9ad4a5