### PR TITLE
docs: refresh README and add in-app instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,21 +37,21 @@ No logs. No identities. No dependencies.
 ## 🚀 How to Use
 
 1. Open `index.html` in a browser (mobile or desktop).
-2. *(Optional)* Click **Generate Key Pair** to create an ECDSA key pair for signing. Use **Export Public Key** to share your public key with others.
-3. Share your session key with your peer and paste theirs to initialize the ratchet.
-4. Select one of the actions from the dropdown:
+2. *(Optional)* Click **Generate Key Pair** to create an ECDSA key pair for signing, then use **Export Public Key** to share it with peers.
+3. Exchange session keys with your partner and click **Initialize Session** to start a ratchet.
+4. For signature verification, paste the sender's public key or choose a saved contact. Use **Save Contact** to store keys with names and avatars for future sessions.
+5. Select one of the actions from the dropdown:
    - **Encrypt Text**
    - **Decrypt Text**
    - **Decrypt Text File**
    - **Encrypt Image**
    - **Decrypt QR**
-5. For encryption, enter your message or upload an image (ensure the image is **100kb or smaller**); for decryption, paste the encrypted string, upload an encrypted text file, or scan/upload a QR code image.
-6. Click the corresponding action button:
+6. Provide the message or upload a file/QR image and click the matching button:
    - **Run** for text encryption/decryption
    - **Encrypt Image** for image encryption
    - **Decode QR** for QR code decryption
-7. Review the result: copy the output, download the QR code, or share via the generated link.
-8. Use the **Reset** button to clear the form and start over.
+7. Review the result: copy it, download the QR code, or use **📤 Share Encrypted Link**. Large outputs automatically download as a text file.
+8. Use **Reset** to clear the form. **Copy Result** copies the output to your clipboard.
 
 ## 🖼️ File and Image Encryption
 

--- a/index.html
+++ b/index.html
@@ -105,6 +105,16 @@
 <body>
   <div class="container">
     <h1><img src="img/beam.png" style="width: 75%; height: 75%"></h1>
+    <details>
+      <summary><strong>Instructions</strong></summary>
+      <ol>
+        <li>Optional: click <strong>Generate Key Pair</strong> and share your public key.</li>
+        <li>Exchange session keys with your peer and press <strong>Initialize Session</strong>.</li>
+        <li>Select an action from the dropdown below.</li>
+        <li>Enter your message or upload a file/QR and choose the matching button.</li>
+        <li>Copy or share the result, save contacts for later, or reset to start over.</li>
+      </ol>
+    </details>
     <label for="action">Select Action:</label>
     <select id="action" onchange="adjustView()">
       <option value="encryptText">Encrypt Text</option>


### PR DESCRIPTION
## Summary
- clarify Beam usage in the README, including saving contacts and sharing encrypted links
- add expandable in-app instructions under the logo for quick guidance

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a6566ea8c833190d0772264432f13